### PR TITLE
fix: Cannot find module '/__enclose_io_memfs__/*' on new Ubuntu or Debian

### DIFF
--- a/node/deps/uv/src/unix/fs.c
+++ b/node/deps/uv/src/unix/fs.c
@@ -1217,6 +1217,13 @@ static int uv__fs_statx(int fd,
   int mode;
   int rc;
 
+//roytan-hack-start
+//for ubuntu 18.04 or debian
+  if (no_statx != 1) {
+    no_statx = 1;
+  }
+//roytan-hack-end
+
   if (no_statx)
     return UV_ENOSYS;
 

--- a/node/lib/child_process.js
+++ b/node/lib/child_process.js
@@ -29,6 +29,7 @@ const {
   getSystemErrorName
 } = require('internal/util');
 const { isArrayBufferView } = require('internal/util/types');
+const deprecate = require('internal/util').deprecate;
 const debug = require('internal/util/debuglog').debuglog('child_process');
 const { Buffer } = require('buffer');
 const { Pipe, constants: PipeConstants } = internalBinding('pipe_wrap');


### PR DESCRIPTION
on new Ubuntu or Debian system, the a.out may have runtime error like this:
```
 ./a.out
internal/modules/cjs/loader.js:797
    throw err;
    ^

Error: Cannot find module '/__enclose_io_memfs__/app.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:794:15)
    at Function.Module._load (internal/modules/cjs/loader.js:687:27)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1031:10)
    at internal/main/run_main_module.js:17:11 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```

The PR can fix it on Ubuntu 18.04 (tested on 14.04, 16.04, 18.04). And also may fix Series10 on the same issue .

related info:
#13 
#11 